### PR TITLE
Set a max width for HTML manuals

### DIFF
--- a/static/R.css
+++ b/static/R.css
@@ -16,6 +16,9 @@
 body, td {
    font-family: sans-serif;
    font-size: 10pt;
+   margin: 0 auto;
+   max-width: 1200px;
+}
 }
 
 body.macintosh, body.macintosh td {


### PR DESCRIPTION
HTML manuals from postdoc and on R-Universe go edge-to-edge on the browser, which is very wide, especially on common large monitors.  I think it's common design and [accessibility](https://www.w3.org/WAI/tutorials/page-structure/styling/) practice to limit width for ease of reading. 

This PR sets a max width of 1200px and centering.