### PR TITLE
Replace chrome font-awesome icon with wasm svg logo

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -206,3 +206,13 @@ a {
   color: #3b71ca;
   border-color: #3b71ca;
 }
+
+/* custom "fontawesome"-style wasm logo */
+
+.fa-wasm::before {
+  /* CC0 https://github.com/WebAssembly/design/issues/980 */
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 107.62 107.62' style='fill:%23ffffff;'%3E%3Cg id='icon'%3E%3Cpath d='M66.12,0c0,.19,0,.38,0,.58a12.34,12.34,0,1,1-24.68,0c0-.2,0-.39,0-.58H0V107.62H107.62V0ZM51.38,96.1,46.14,70.17H46L40.39,96.1H33.18L25,58h7.13L37,83.93h.09L42.94,58h6.67L54.9,84.25H55L60.55,58h7L58.46,96.1Zm39.26,0-2.43-8.48H75.4L73.53,96.1H66.36L75.59,58H86.83L98,96.1Z'/%3E%3Cpolygon points='79.87 67.39 76.76 81.37 86.44 81.37 82.87 67.39 79.87 67.39'/%3E%3C/g%3E%3C/svg%3E");
+  mask-image: no-repeat;
+  padding: 0 1rem 0 0;
+  content: "";
+}

--- a/dashboard.css
+++ b/dashboard.css
@@ -209,7 +209,7 @@ a {
 
 /* custom "fontawesome"-style wasm logo */
 
-.fa-wasm::before {
+.fa-wasm-custom::before {
   /* CC0 https://github.com/WebAssembly/design/issues/980 */
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 107.62 107.62' style='fill:%23ffffff;'%3E%3Cg id='icon'%3E%3Cpath d='M66.12,0c0,.19,0,.38,0,.58a12.34,12.34,0,1,1-24.68,0c0-.2,0-.39,0-.58H0V107.62H107.62V0ZM51.38,96.1,46.14,70.17H46L40.39,96.1H33.18L25,58h7.13L37,83.93h.09L42.94,58h6.67L54.9,84.25H55L60.55,58h7L58.46,96.1Zm39.26,0-2.43-8.48H75.4L73.53,96.1H66.36L75.59,58H86.83L98,96.1Z'/%3E%3Cpolygon points='79.87 67.39 76.76 81.37 86.44 81.37 82.87 67.39 79.87 67.39'/%3E%3C/g%3E%3C/svg%3E");
   mask-image: no-repeat;

--- a/frontend/frontend.html
+++ b/frontend/frontend.html
@@ -519,7 +519,7 @@
             <span class="package-details-linux"></span>
             <a class="text-dark linux-binary-help" target="_blank" href="https://github.com/r-universe-org/help#does-r-universe-have-linux-binaries"><i class="far fa-question-circle"></i></a><br>
           <span class="wasm-binaries d-none">
-            <a style="width: 20px" class="fab fa-wasm package-details-logs text-dark text-decoration-none grow-on-over"></a><span class="package-details-wasm"></span>
+            <a style="width: 20px" class="fab fa-wasm-custom package-details-logs text-dark text-decoration-none grow-on-over"></a><span class="package-details-wasm"></span>
              <a class="text-dark wasm-binary-help" target="_blank" href="https://github.com/r-universe-org/help#how-to-use-webassembly-binaries"><i class="far fa-question-circle"></i></a><br>
           </span>
           <a style="width: 20px" class="fas fa-file-pdf package-details-logs text-dark text-decoration-none grow-on-over"></a>

--- a/frontend/frontend.html
+++ b/frontend/frontend.html
@@ -519,7 +519,7 @@
             <span class="package-details-linux"></span>
             <a class="text-dark linux-binary-help" target="_blank" href="https://github.com/r-universe-org/help#does-r-universe-have-linux-binaries"><i class="far fa-question-circle"></i></a><br>
           <span class="wasm-binaries d-none">
-            <a style="width: 20px" class="fab fa-chrome package-details-logs text-dark text-decoration-none grow-on-over"></a><span class="package-details-wasm"></span>
+            <a style="width: 20px" class="fab fa-wasm package-details-logs text-dark text-decoration-none grow-on-over"></a><span class="package-details-wasm"></span>
              <a class="text-dark wasm-binary-help" target="_blank" href="https://github.com/r-universe-org/help#how-to-use-webassembly-binaries"><i class="far fa-question-circle"></i></a><br>
           </span>
           <a style="width: 20px" class="fas fa-file-pdf package-details-logs text-dark text-decoration-none grow-on-over"></a>

--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -145,7 +145,7 @@ function run_icon(bin, desc){
   if(bin.type == 'pending')
     return $('<span></span>');
   var iconmap = {
-    wasm: "chrome",
+    wasm: "wasm",
     src : "linux",
     win : "windows",
     mac : "apple"
@@ -159,17 +159,21 @@ function run_icon(bin, desc){
   } else {
     var i = $("<i>", {class : 'fab fa-' + iconmap[type]});
     var a = $("<a>").attr('href', buildurl).append(i).css('margin-left', '5px');
+
+    // until there's an official FontAwesome wasm logo, current logo uses svg mask + background color
+    const attr = type == 'wasm' ? 'background-color' : 'color';
+
     // can be "success" or "Succeeded"
     if(status.match(/succ/i)){
-      i.css('color', '#22863a');
+      i.css(attr, '#22863a');
     } else if(status === 'arm64-failure'){
-      i.css('color', '#cb2431');
+      i.css(attr, '#cb2431');
     } else if(type == 'src'){
-      i.css('color', '#cb2431');
+      i.css(attr, '#cb2431');
     } else if(type == 'wasm'){
-      i.css('color', '#e0e0e0');
+      i.css(attr, '#e0e0e0');
     } else {
-      i.css('color', 'slategrey');
+      i.css(attr, 'slategrey');
     }
   }
   //return $('<span></span>').append(a);

--- a/frontend/frontend.js
+++ b/frontend/frontend.js
@@ -145,7 +145,7 @@ function run_icon(bin, desc){
   if(bin.type == 'pending')
     return $('<span></span>');
   var iconmap = {
-    wasm: "wasm",
+    wasm: "wasm-custom",
     src : "linux",
     win : "windows",
     mac : "apple"


### PR DESCRIPTION
Font Awesome doesn't ship a wasm icon yet. Instead, I added a specific style for `.fa-wasm-custom` (named to avoid any unintended naming conflicts should FA release a `wasm` icon) to use a bundled svg icon.

One wrinkle with this style is that using an svg mask requires the use of `background-color` instead of `color` to change the icon's apparent color, so there's a little check for which icon is being styled in the frontend js code. 

I wasn't able to properly test the changes -- I think the the docs in the README might be out of date. Assuming `homepage` was renamed to `fontend`, I still wasn't able to get the local testing configured to properly test that the js is building the logos. The changes are pretty minor so hopefully the intention is self-evident.